### PR TITLE
build(x264-sys): update to x264-sys v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.3.0"
 authors = ["Ram <quadrupleslap@gmail.com>"]
 
 [dependencies]
-x264-sys = "0.1"
+x264-sys = "0.2.0"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,16 +8,17 @@ use x264::*;
 pub struct Data<'a> {
     ptr: *mut x264_nal_t,
     len: usize,
-    spooky: PhantomData<&'a [x264_nal_t]>
+    spooky: PhantomData<&'a [x264_nal_t]>,
 }
 
 impl<'a> Data<'a> {
     #[doc(hidden)]
-    pub unsafe fn from_raw_parts(
-        ptr: *mut x264_nal_t,
-        len: usize
-    ) -> Self {
-        Data { ptr, len, spooky: PhantomData }
+    pub unsafe fn from_raw_parts(ptr: *mut x264_nal_t, len: usize) -> Self {
+        Data {
+            ptr,
+            len,
+            spooky: PhantomData,
+        }
     }
 
     /// The length (in NAL units, **not** in bytes) of this data sequence.
@@ -40,25 +41,16 @@ impl<'a> Data<'a> {
 
         assert!(i < self.len);
 
-        let nal = unsafe {
-            *self.ptr.offset(i as isize)
-        };
+        let nal = unsafe { *self.ptr.add(i) };
 
         Unit {
-            priority:
-                match nal.i_ref_idc {
-                    D => Priority::Disposable,
-                    L => Priority::Low,
-                    H => Priority::High,
-                    _ => Priority::Highest,
-                },
-            payload:
-                unsafe {
-                    slice::from_raw_parts(
-                        nal.p_payload,
-                        nal.i_payload as usize
-                    )
-                }
+            priority: match nal.i_ref_idc {
+                D => Priority::Disposable,
+                L => Priority::Low,
+                H => Priority::High,
+                _ => Priority::Highest,
+            },
+            payload: unsafe { slice::from_raw_parts(nal.p_payload, nal.i_payload as usize) },
         }
     }
 
@@ -69,14 +61,12 @@ impl<'a> Data<'a> {
         } else {
             let (a, b) = unsafe {
                 let a = *self.ptr;
-                let b = *self.ptr.offset((self.len - 1) as isize);
+                let b = *self.ptr.add(self.len - 1);
                 (a, b)
             };
 
-            let start  = a.p_payload;
-            let length = b.p_payload as usize
-                       + b.i_payload as usize
-                       - start as usize;
+            let start = a.p_payload;
+            let length = b.p_payload as usize + b.i_payload as usize - start as usize;
 
             unsafe { slice::from_raw_parts(start, length) }
         }
@@ -86,7 +76,7 @@ impl<'a> Data<'a> {
 /// A single NAL unit.
 pub struct Unit<'a> {
     priority: Priority,
-    payload: &'a [u8]
+    payload: &'a [u8],
 }
 
 impl<'a> Unit<'a> {
@@ -107,11 +97,11 @@ impl<'a> AsRef<[u8]> for Unit<'a> {
 /// The importance of a given unit.
 pub enum Priority {
     /// Not important at all.
-    Disposable = nal_priority_e::NAL_PRIORITY_DISPOSABLE as i32,
+    Disposable = nal_priority_e_NAL_PRIORITY_DISPOSABLE as i32,
     /// Not very important.
-    Low = nal_priority_e::NAL_PRIORITY_LOW as i32,
+    Low = nal_priority_e_NAL_PRIORITY_LOW as i32,
     /// Pretty important.
-    High = nal_priority_e::NAL_PRIORITY_HIGH as i32,
+    High = nal_priority_e_NAL_PRIORITY_HIGH as i32,
     /// Extremely important.
-    Highest = nal_priority_e::NAL_PRIORITY_HIGHEST as i32,
+    Highest = nal_priority_e_NAL_PRIORITY_HIGHEST as i32,
 }


### PR DESCRIPTION
This commit also runs rustfmt, and fixes some low-hanging clippy lints
(such as the use of decprecated mem::uninitialized()).

Tested: Compiled and ran example.